### PR TITLE
Remove use of anaconda channels

### DIFF
--- a/bin/envs/HuGo_removal.yaml
+++ b/bin/envs/HuGo_removal.yaml
@@ -2,7 +2,7 @@ name: HuGo_removal
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
     - bowtie2==2.3.4.3
     - samtools==1.9

--- a/bin/envs/Illumina_ref_CutPrimers.yaml
+++ b/bin/envs/Illumina_ref_CutPrimers.yaml
@@ -3,7 +3,7 @@ channels:
   - bioconda
   - conda-forge
   - intel
-  - defaults
+
 dependencies:
   - python=3.7
   - pandas==1.1.4

--- a/bin/envs/Illumina_ref_alignment.yaml
+++ b/bin/envs/Illumina_ref_alignment.yaml
@@ -2,7 +2,7 @@ name: Illumina_ref_alignment
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
     - samtools==1.10
     - bowtie2==2.3.5

--- a/bin/envs/Jovian_coverage_statistics.yaml
+++ b/bin/envs/Jovian_coverage_statistics.yaml
@@ -2,7 +2,7 @@ name: Jovian_coverage_statistics
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
   - python==3.8.5
   - samtools==1.10

--- a/bin/envs/Jovian_helper_environment.yaml
+++ b/bin/envs/Jovian_helper_environment.yaml
@@ -2,7 +2,7 @@ name: Jovian_helper
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
   - bowtie2==2.3.4.3
   - blast==2.9.0

--- a/bin/envs/Jovian_master_environment.yaml
+++ b/bin/envs/Jovian_master_environment.yaml
@@ -1,7 +1,7 @@
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
   - eumetsat
 dependencies:
   - snakemake==5.20.1

--- a/bin/envs/Krona_plot.yaml
+++ b/bin/envs/Krona_plot.yaml
@@ -2,7 +2,7 @@ name: Krona_plot
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
     - krona==2.7.1
     - pandas==0.23.4

--- a/bin/envs/MultiQC_report.yaml
+++ b/bin/envs/MultiQC_report.yaml
@@ -2,6 +2,6 @@ name: MultiQC_report
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
     - multiqc==1.9

--- a/bin/envs/Nano_clean.yaml
+++ b/bin/envs/Nano_clean.yaml
@@ -3,8 +3,7 @@ channels:
   - bioconda
   - conda-forge
   - intel
-  - anaconda
-  - defaults
+
 dependencies:
   - python=3.7
   - minimap2==2.17

--- a/bin/envs/Nano_ref_alignment.yaml
+++ b/bin/envs/Nano_ref_alignment.yaml
@@ -2,7 +2,7 @@ name: Nanopore_ref_alignment
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
     - minimap2==2.17
     - samtools==1.10

--- a/bin/envs/Nano_ref_consensus.yaml
+++ b/bin/envs/Nano_ref_consensus.yaml
@@ -3,8 +3,7 @@ channels:
   - bioconda
   - conda-forge
   - intel
-  - anaconda
-  - defaults
+
 dependencies:
   - python=3.7
   - pysam==0.16.0.1

--- a/bin/envs/QC_and_clean.yaml
+++ b/bin/envs/QC_and_clean.yaml
@@ -2,7 +2,7 @@ name: QC_and_clean
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
     - fastqc==0.11.8
     - trimmomatic==0.38

--- a/bin/envs/Sequence_analysis.yaml
+++ b/bin/envs/Sequence_analysis.yaml
@@ -2,7 +2,7 @@ name: Sequence_analysis
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
     - prodigal==2.6.3
     - tabix==0.2.6

--- a/bin/envs/data_wrangling.yaml
+++ b/bin/envs/data_wrangling.yaml
@@ -2,7 +2,7 @@ name: data_wrangling
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
     - biopython==1.72
     - pandas==0.23.4

--- a/bin/envs/de_novo_assembly.yaml
+++ b/bin/envs/de_novo_assembly.yaml
@@ -2,7 +2,7 @@ name: de_novo_assembly
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
     - spades==3.11.0=py36_0
     - seqtk==1.2.0

--- a/bin/envs/heatmaps.yaml
+++ b/bin/envs/heatmaps.yaml
@@ -2,7 +2,7 @@ name: heatmaps
 channels:
   - conda-forge
   - bioconda
-  - defaults
+
 dependencies:
   - bokeh=1.0.1
   - numpy=1.15.4

--- a/bin/envs/mgkit_lca.yaml
+++ b/bin/envs/mgkit_lca.yaml
@@ -2,6 +2,6 @@ name: mgkit_lca
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
     - mgkit==0.3.4

--- a/bin/envs/scaffold_classification.yaml
+++ b/bin/envs/scaffold_classification.yaml
@@ -2,6 +2,6 @@ name: scaffold_classification
 channels:
   - bioconda
   - conda-forge
-  - defaults
+
 dependencies:
     - blast==2.9.0

--- a/files/acknowledgements.md
+++ b/files/acknowledgements.md
@@ -22,8 +22,6 @@
 |Lofreq|Wilm, A., et al., LoFreq: a sequence-quality aware, ultra-sensitive variant caller for uncovering cell-population heterogeneity from high-throughput sequencing datasets. 2012. 40(22): p. 11189-11201.|http://csb5.github.io/lofreq/|
 |Minimap2|Li, H., Minimap2: pairwise alignment for nucleotide sequences. Bioinformatics, 2018.|https://github.com/lh3/minimap2|
 |MultiQC|Ewels, P., et al., MultiQC: summarize analysis results for multiple tools and samples in a single report. 2016. 32(19): p. 3047-3048.|https://multiqc.info/|
-|Nb_conda|NA|https://github.com/Anaconda-Platform/nb_conda|
-|Nb_conda_kernels|NA|https://github.com/Anaconda-Platform/nb_conda_kernels|
 |Nginx|NA|https://www.nginx.com/|
 |Numpy|Walt, S. V. D., Colbert, S. C., & Varoquaux, G. (2011). The NumPy array: a structure for efficient numerical computation. Computing in Science & Engineering, 13(2), 22-30.|http://www.numpy.org/|
 |Pandas|McKinney, W. Data structures for statistical computing in python. in Proceedings of the 9th Python in Science Conference. 2010. Austin, TX.|https://pandas.pydata.org/|


### PR DESCRIPTION
As per EMBL's new rules, EMBL-EBI cannot use Anaconda repos. Removed all references to `defaults` or `anaconda` channels.

https://www.embl.org/internal-information/updates/access-prevented-to-anaconda/ 